### PR TITLE
Flipped subject & object order to match Mondo mapping file

### DIFF
--- a/GeneMap.ipynb
+++ b/GeneMap.ipynb
@@ -37,9 +37,9 @@
     "OMIM -> HGNC\n",
     "\n",
     "# These genes depend on why panther only uses ENSEMBL ids sometimes, maybe these can't be mapped?\n",
-    "ENSEMBL:ENSDARG -> ZFIN \n",
+    "ENSEMBL:ENSDARG -> ZFIN\n",
     "ENSEMBL:ENSGALG -> NCBIGene\n",
-    "ENSEMBL:ENSMUSG -> MGI \n",
+    "ENSEMBL:ENSMUSG -> MGI\n",
     "ENSEMBL:ENSRNOG -> RGD\"\"\""
    ]
   },

--- a/monarch_gene_mapping/gene_mapping.py
+++ b/monarch_gene_mapping/gene_mapping.py
@@ -18,17 +18,16 @@ def bgi2sssom(bgi) -> Dict:
     """
     gene = bgi['basicGeneticEntity']
     xref = [x['id'].replace("NCBI_Gene", "NCBIGene").replace("NCBI_GENE", "NCBIGene")
-            for x in gene['crossReferences']
-            if "NCBI" in x['id']]
+            for x in gene['crossReferences']]
     prim_id = gene['primaryId'].replace("DRSC:XB:", "Xenbase:")
     if len(xref):
         ncbi_xref = xref[0]
     else:
         return None
     return {
-        "subject_id": ncbi_xref,
+        "subject_id": prim_id,
         "predicate_id": "skos:exactMatch",
-        "object_id": prim_id,
+        "object_id": ncbi_xref,
         "mapping_justification": "semapv:UnspecifiedMatching",
     }
 
@@ -58,19 +57,19 @@ def alliance_ncbi_mapping() -> DataFrame:
 
 
 def hgnc_mapping(subject_column,
-                 subject_curie_prefix,
+                 object_curie_prefix,
                  predicate_id="skos:exactMatch",
-                 subject_list_delimiter=None) -> DataFrame:
+                 object_list_delimiter=None) -> DataFrame:
     hgnc = pd.read_csv("data/hgnc/hgnc_complete_set.txt", sep="\t", dtype="string")
 
-    hgnc.rename(columns={subject_column: "subject_id", "hgnc_id": "object_id"}, inplace=True)
+    hgnc.rename(columns={"hgnc_id": "subject_id", subject_column: "object_id"}, inplace=True)
 
-    # if the subject column has a list, use explode to roll it down and make a SSSOM triple for each
-    if subject_list_delimiter is not None \
-            and len(hgnc[hgnc['subject_id'].str.contains(subject_list_delimiter)]) > 0:
-        hgnc = hgnc.assign(subject_id=hgnc.subject_id.str.split("|")).explode('subject_id')
+    # if the object column has a list, use explode to roll it down and make a SSSOM triple for each
+    if object_list_delimiter is not None \
+            and len(hgnc[hgnc['object_id'].str.contains(object_list_delimiter)]) > 0:
+        hgnc = hgnc.assign(object_id=hgnc.object_id.str.split("|")).explode('object_id')
 
-    hgnc["subject_id"] = subject_curie_prefix + hgnc["subject_id"]
+    hgnc["object_id"] = object_curie_prefix + hgnc["object_id"]
     hgnc["predicate_id"] = predicate_id
     hgnc["mapping_justification"] = "semapv:UnspecifiedMatching"
     hgnc = hgnc[["subject_id", "predicate_id", "object_id", "mapping_justification"]]
@@ -91,14 +90,14 @@ def generate_gene_mappings() -> DataFrame:
     assert(len(ncbi_to_hgnc) > 40000)
     mapping_dataframes.append(ncbi_to_hgnc)
 
-    omim_to_hgnc = hgnc_mapping("omim_id", "OMIM:", subject_list_delimiter="\\|")
+    omim_to_hgnc = hgnc_mapping("omim_id", "OMIM:", object_list_delimiter="\\|")
     assert(len(omim_to_hgnc) > 16000)
     mapping_dataframes.append(omim_to_hgnc)
 
     uniprot_to_hgnc = hgnc_mapping("uniprot_ids",
                                    "UniProtKB:",
                                    predicate_id="skos:closeMatch",
-                                   subject_list_delimiter="\\|")
+                                   object_list_delimiter="\\|")
     assert(len(uniprot_to_hgnc) > 20000)
     mapping_dataframes.append(uniprot_to_hgnc)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monarch_gene_mapping"
-version = "0.1.1"
+version = "0.1.2"
 description = "Project for mapping source namespaces to preffered namespaces in Monarch Initiative"
 authors = [
     "Tim Putman <putmantime@users.noreply.github.com>",


### PR DESCRIPTION
There shouldn't be any change to the semantic meaning from the order change, since we're just using close and exact match predicates.

I also included all cross references from Alliance BGI files rather than just NCBI.