### PR TITLE
Add mapping for ENSEMBL:ENSGAL

### DIFF
--- a/monarch_gene_mapping/download.yaml
+++ b/monarch_gene_mapping/download.yaml
@@ -38,3 +38,9 @@
   url: http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt
   local_name: data/hgnc/hgnc_complete_set.txt
   tag: hgnc_gene
+
+  # ENSEMBL:ENSGAL
+
+  url: https://ftp.ncbi.nih.gov/gene/DATA/gene2ensembl.gz
+  local_name: data/ensembl/gene2ensembl.gz
+  tag: gene_2_ensembl


### PR DESCRIPTION
Added ensembl2gene.qz to downloads
new function to generate mapping for ensembl to NCBI gene
added new mapping to the main mapping function.

Note: I'm not entirely certain about the IDs used here. I selected GeneID and added the NCBIGene: curie based on the information here:

https://ftp.ncbi.nih.gov/gene/DATA/README

Please let me know if you see any problems or have questions.