### PR TITLE
Fix download and run error for hgnc and ensembl

### DIFF
--- a/monarch_gene_mapping/download.yaml
+++ b/monarch_gene_mapping/download.yaml
@@ -40,7 +40,7 @@
   tag: hgnc_gene
 
   # ENSEMBL:ENSGAL
-
+-
   url: https://ftp.ncbi.nih.gov/gene/DATA/gene2ensembl.gz
   local_name: data/ensembl/gene2ensembl.gz
   tag: gene_2_ensembl


### PR DESCRIPTION
Missing `-` symbol in download.yaml broke downloading hgnc and ensembl.
closes #14